### PR TITLE
Load sprintf.js as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/js/dist/sprintf.js"]
+	path = src/js/dist/sprintf.js
+	url = git@github.com:alexei/sprintf.js.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 include ./Config.mk
-.PHONY: deploy server tab2space sprintf-1.0.0
+.PHONY: deploy server tab2space
 
 do_nothing:
 
@@ -13,8 +13,3 @@ server:
 
 tab2space:
 	find src/js/ -iname *.js -exec sed -i s/'\t'/'    '/g '{}' \;
-
-sprintf-1.0.0:
-	# get from github
-	cd src/js/libs && wget https://raw.githubusercontent.com/alexei/sprintf.js/1.0.0/src/sprintf.js
-

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>OceanWorldClicker</title>
     <link rel="stylesheet" type="text/css" href="css/style.css">
-    <script type="text/javascript" src="js/libs/sprintf.js"></script>
+    <script type="text/javascript" src="js/dist/sprintf.js/src/sprintf.js"></script>
 </head>
 <body>
     <table style="width:100%;"><tr>


### PR DESCRIPTION
At first I thought you simply forgot to add the javascript file for sprintf. So I added it with a git submodule. But you already managed this with the help of a make file. :+1: 

Nevertheless, here is my patch to use git submodule. Feel free to refuse it :)
But in the long run, imho I think its easier to manage dependencies with submodules instead of custom scripts with wget/curl commands.
